### PR TITLE
point to specific IAM OIDC link

### DIFF
--- a/hugo/content/posts/TFC_P1.md
+++ b/hugo/content/posts/TFC_P1.md
@@ -30,7 +30,7 @@ OpenID Connect (OIDC) is the new thing all the kids are raving about. Previously
 #### Creating the OIDC Provider
 
 1. You will need to create a terraform workspace separate from the new service that you want to bootstrap. Ideally this is a place where other "global" or account level AWS resources live.
-2. Once that is created, you need to follow [these awful instructions](https://docs.aws.amazon.com/IAM/latest/UserGuide/ to grab the thumbprint for the OIDC provider resource. You will need to remove all `:`'s from the thumbprint.
+2. Once that is created, you need to follow [these awful instructions](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc_verify-thumbprint.html) to grab the thumbprint for the OIDC provider resource. You will need to remove all `:`'s from the thumbprint.
 3. You will deploy the OpenID Provider resource in the previously mentioned workspace:
 
 ```hcl


### PR DESCRIPTION
While attempting to follow your tutorial, I was unable to complete this step with your instructions that were missing the complete link. I propose you include the entire link. Thanks! https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc_verify-thumbprint.html

As an alternative, [the documentation states](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc_verify-thumbprint.html) you can just have the console fetch the thumbprint for you:
> You can create an IAM OIDC identity provider with [the AWS Command Line Interface, the Tools for Windows PowerShell, or the IAM API](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc.html#manage-oidc-provider-cli). When you use these methods, you must obtain the thumbprint manually and supply it to AWS. When you create an OIDC identity provider with [the IAM console](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc.html), the console attempts to fetch the thumbprint for you. We recommend that you also obtain the thumbprint for your OIDC IdP manually and verify that the console fetched the correct thumbprint.

In this case https://token.actions.githubusercontent.com. Maybe that would be a quicker way for consumers of this article to test this out? Food for thought...

PS - thanks for writing this tutorial at all. It's a great motivation for me to actually implement it in my organization!